### PR TITLE
Feature/add overlay code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # eagle-id-front-end
 non-functional, bareminimum front-end code to help https://ayn-ai.github.io/eyn-api-doc/#identity-checks
+
+# ToDo
+ [ ] Functional, bareminimum front-end

--- a/code-samples/Overlay.js
+++ b/code-samples/Overlay.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { isMobile } from "react-device-detect";
+
+const styles = theme => ({
+    overlay: {
+        position: 'absolute',
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        margin: "auto"
+    },
+});
+
+class Overlay extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            overlay: "document"
+        };
+    }
+
+    render() {
+        return (
+        <div className={classes.overlay}>
+        { (this.state.overlay === "document")?
+        <img src={ isMobile? "svg/overlay_document_mobile.svg" : "svg/overlay_document.svg"} width="100%" alt="document overlay" /> : <></>
+        }
+        { (this.state.overlay === "selfie")?
+         <img src={ isMobile? "svg/overlay_selfie_mobile.svg" : "svg/overlay_selfie.svg"} width="100%" alt="selfie overlay" /> : <></>
+        }
+        </div>
+        );
+      }
+}
+
+Overlay.propTypes = {
+};
+
+export default withStyles(styles)(Overlay);

--- a/svg/overlay_document.svg
+++ b/svg/overlay_document.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg viewBox="0 0 100 100"
+     preserveAspectRatio="none"
+     xmlns="http://www.w3.org/2000/svg"
+     version="1.1">
+	<mask id="documentOverlay">
+		<rect x="0" y="0" width="100%" height="100%" fill="white"/>
+		<rect x="10%" y="5%" width="80%" height="50%" rx="5%" fill="black"/>
+	</mask>
+	<rect fill="rgba(0, 0, 0, 0.7)" x="0" y="0" width="100%" height="100%" mask="url(#documentOverlay)" />
+</svg>

--- a/svg/overlay_document_mobile.svg
+++ b/svg/overlay_document_mobile.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg viewBox="0 0 50 100"
+     preserveAspectRatio="none"
+     xmlns="http://www.w3.org/2000/svg"
+     version="1.1">
+	<mask id="documentOverlay">
+		<rect x="0" y="0" width="100%" height="100%" fill="white"/>
+                <rect x="2.5%" y="5%" width="95%" height="35%" rx="5%" fill="black"/>
+        </mask>
+        <rect fill="rgba(0, 0, 0, 0.7)" x="0" y="0" width="100%" height="100%" mask="url(#documentOverlay)" />
+</svg>

--- a/svg/overlay_selfie.svg
+++ b/svg/overlay_selfie.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg viewBox="0 0 100 100"
+     preserveAspectRatio="none"
+     xmlns="http://www.w3.org/2000/svg"
+     version="1.1">
+	<mask id="selfieOverlay">
+		<rect x="0" y="0" width="100%" height="100%" fill="white"/>
+		<circle cx="50%" cy="25%" r="25%" fill="black"/>
+	</mask>
+        <rect fill="rgba(0, 0, 0, 0.7)" x="0" y="0" width="100%" height="100%" mask="url(#selfieOverlay)" />
+</svg>

--- a/svg/overlay_selfie_mobile.svg
+++ b/svg/overlay_selfie_mobile.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg viewBox="0 0 50 100"
+     preserveAspectRatio="none"
+     xmlns="http://www.w3.org/2000/svg"
+     version="1.1">
+	<mask id="selfieOverlay">
+		<rect x="0" y="0" width="100%" height="100%" fill="white"/>
+		<circle cx="50%" cy="25%" r="25%" fill="black"/>
+	</mask>
+        <rect fill="rgba(0, 0, 0, 0.7)" x="0" y="0" width="100%" height="100%" mask="url(#selfieOverlay)" />
+</svg>


### PR DESCRIPTION
@ratuliut please review. This PR adds an example of the overlay used in `eagle-id` for document and selfie overlay in the case of a `mobile` and for `web`.